### PR TITLE
Add spot IP address reservation

### DIFF
--- a/network.md
+++ b/network.md
@@ -40,6 +40,7 @@ The following devices have permanent IPs in the DHCP server of the lab router:
 | Falcon 1                       | WIFI          | `192.168.0.141`   |
 | Hovergames  Drone 1            | WIFI          | `192.168.0.151`   |
 | Hovergames  Drone 2            | WIFI          | `192.168.0.152`   |
+| Spot                           | WIFI          | `192.168.2.11`    |
 
 ## VLAN
 


### PR DESCRIPTION
I reserved an IP address for the Spot quadruped and added it to the documentation.